### PR TITLE
chore: pin bun to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "biome check --write ."
   },
   "type": "module",
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
     "@biomejs/biome": "2.5.10",


### PR DESCRIPTION
A lockfile generated by bun 1.4 is lockfileVersion 2, which 1.3.14 cannot
parse. CI resolves its bun from packageManager, so any lockfile regeneration
fails every workflow at its first step, before lint, types, tests or build.
Local gates stay green because the local bun is already 1.4.

Claude-Session: https://claude.ai/code/session_018gJXoLpdrKd1qJVJy4gMPb
